### PR TITLE
Add timestamp query string to avoid cached responses

### DIFF
--- a/manpages/install.fish
+++ b/manpages/install.fish
@@ -5,7 +5,11 @@ if ! command -q curl
     exit 1
 end
 
-set http_code (curl --write-out "%{http_code}" --silent "https://raw.githubusercontent.com/marcransome/pond/main/manpages/pond.1" -o /usr/local/share/man/man1/pond.1)
+set timestamp (date +%s)
+
+echo $timestamp
+
+set http_code (curl --write-out "%{http_code}" --silent "https://raw.githubusercontent.com/marcransome/pond/main/manpages/pond.1?$timestamp" -o /usr/local/share/man/man1/pond.1)
 set curl_exit $status
 
 if test $curl_exit -ne 0

--- a/manpages/install.fish
+++ b/manpages/install.fish
@@ -7,8 +7,6 @@ end
 
 set timestamp (date +%s)
 
-echo $timestamp
-
 set http_code (curl --write-out "%{http_code}" --silent "https://raw.githubusercontent.com/marcransome/pond/main/manpages/pond.1?$timestamp" -o /usr/local/share/man/man1/pond.1)
 set curl_exit $status
 

--- a/manpages/install.sh
+++ b/manpages/install.sh
@@ -7,7 +7,9 @@ if ! command -v curl >/dev/null; then
     exit 1
 fi
 
-http_code=$(curl --write-out "%{http_code}" --silent "https://raw.githubusercontent.com/marcransome/pond/main/manpages/pond.1" -o /usr/local/share/man/man1/pond.1)
+timestamp=$(date +%s)
+
+http_code=$(curl --write-out "%{http_code}" --silent "https://raw.githubusercontent.com/marcransome/pond/main/manpages/pond.1?$timestamp" -o /usr/local/share/man/man1/pond.1)
 curl_exit=$?
 
 if [[ $curl_exit -ne 0 ]]; then


### PR DESCRIPTION
Add timestamp query string to man page URL to avoid cached responses from proxies.