### PR TITLE
Remove tap-diff

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,6 @@ RUN microdnf update -y \
   && microdnf install -y fish \
   && microdnf clean all -y
 
-RUN npm install -g tap-diff
 RUN rm -rf /usr/share/doc
 RUN /usr/bin/fish -c "curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source; and fisher install jorgebucaran/{fisher,fishtape}"
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,6 @@ However you choose to work, contributions are most welcome.
 ## Acknowledgements
 
 * Pond icon made by [Freepik](https://www.flaticon.com/authors/freepik) from [www.flaticon.com](https://www.flaticon.com/)
-* Pond's [workflow](https://github.com/marcransome/pond/actions) uses the [fishtape](https://github.com/jorgebucaran/fishtape) test runner and [tap-diff](https://github.com/axross/tap-diff) to make things pretty
 
 ## License
 

--- a/tools/test
+++ b/tools/test
@@ -1,3 +1,3 @@
 #!/usr/bin/fish
 
-fishtape /workspaces/pond/tests/*.fish | tap-diff
+fishtape /workspaces/pond/tests/*.fish


### PR DESCRIPTION
This change removes [`tap-diff`](https://github.com/axross/tap-diff) which is now unmaintained and publicly archived.